### PR TITLE
Last.fm - Add new option to use `artistname - songname` as discord activity name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Prepare environment
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
-                  node-version: "16"
+                  node-version: "20"
 
             - run: npm install --global pnpm
 

--- a/plugins/Last.fm/src/manager.ts
+++ b/plugins/Last.fm/src/manager.ts
@@ -72,7 +72,7 @@ async function update() {
     }
 
     const activity = {
-        name: currentSettings.appName || Constants.DEFAULT_APP_NAME,
+        name: currentSettings.altActivityName ? `${lastTrack.artist} - ${lastTrack.name}` : (currentSettings.appName || Constants.DEFAULT_APP_NAME),
         flags: 0,
         type: currentSettings.listeningTo ? ActivityType.LISTENING : ActivityType.PLAYING,
         details: lastTrack.name,

--- a/plugins/Last.fm/src/ui/pages/Settings.tsx
+++ b/plugins/Last.fm/src/ui/pages/Settings.tsx
@@ -87,6 +87,14 @@ export default React.memo(function Settings() {
             />
             <FormDivider />
             <FormSwitchRow
+                label="Use alternate activity name"
+                subLabel='Use "artist - songname" as activity name instead of the set Application Name'
+                leading={<FormIcon source={getAssetIDByName("ic_information_24px")} />}
+                value={settings.altActivityName}
+                onValueChange={(value: boolean) => settings.altActivityName = value}
+            />
+            <FormDivider />
+            <FormSwitchRow
                 label="Hide when Spotify is running"
                 subLabel="Hide the status when a Spotify activity is detected"
                 leading={<FormIcon source={getAssetIDByName("img_account_sync_spotify_light_and_dark")} />}

--- a/plugins/defs.d.ts
+++ b/plugins/defs.d.ts
@@ -34,6 +34,7 @@ export type LFMSettings = {
     listeningTo: boolean;
     ignoreSpotify: boolean;
     verboseLogging: boolean;
+    altActivityName: boolean;
 };
 
 export type Track = {


### PR DESCRIPTION
Adds a toggle to make the Discord activity appear as

![share_4283205177025710641](https://github.com/user-attachments/assets/422c7e25-53e8-4e8a-a9f4-e20601cb5e71)

instead of 

![share_4417950562164982620](https://github.com/user-attachments/assets/7b1c9c7f-e123-4b41-85e6-eeacd240a616)

This allows the display behavior to match the LastFM Vencord plugin, which also has this option.

I also bumped the node and runner versions since my code wasn't compiling with the existing versions.

Can be tested by using https://enncoded.github.io/letup/Last.fm/