### PR TITLE
fix(Last.fm): set timestamp to ms

### DIFF
--- a/plugins/Last.fm/src/manager.ts
+++ b/plugins/Last.fm/src/manager.ts
@@ -91,7 +91,7 @@ async function update() {
     // Set timestamps
     if (currentSettings.showTimestamp) {
         activity.timestamps = {
-            start: Date.now() / 1000 | 0
+            start: Date.now()| 0
         };
     }
 


### PR DESCRIPTION
The Discord RPC timestamp is formatted in milliseconds instead of seconds.